### PR TITLE
fix openocd bcm2835 driver bugs

### DIFF
--- a/src/jtag/drivers/bcm2835gpio.c
+++ b/src/jtag/drivers/bcm2835gpio.c
@@ -96,7 +96,10 @@ static uint32_t lev = 0;
 static int bcm2835gpio_read(void)
 {
         // the first read back is unreliable, so do a dummy ready before returning data
-        lev = GPIO_LEV;
+        // lev = GPIO_LEV;
+        GPIO_SET = 0;
+        GPIO_SET = 0;
+        GPIO_SET = 0;
   
 	return !!(GPIO_LEV & 1<<tdo_gpio);
 }
@@ -106,7 +109,8 @@ static void bcm2835gpio_write(int tck, int tms, int tdi)
 	uint32_t set = tck<<tck_gpio | tms<<tms_gpio | tdi<<tdi_gpio;
 	uint32_t clear = !tck<<tck_gpio | !tms<<tms_gpio | !tdi<<tdi_gpio;
 
-	lev = GPIO_LEV;
+        GPIO_SET = 0;
+	// lev = GPIO_LEV;
 	GPIO_SET = set;
 	GPIO_CLR = clear;
 

--- a/src/jtag/drivers/bcm2835gpio.c
+++ b/src/jtag/drivers/bcm2835gpio.c
@@ -469,7 +469,7 @@ static int bcm2835gpio_init(void)
 	}
 
 	/* set 4mA drive strength, slew rate limited, hysteresis on */
-	pads_base[BCM2835_PADS_GPIO_0_27_OFFSET] = 0x5a000008 + 1;
+	pads_base[BCM2835_PADS_GPIO_0_27_OFFSET] = 0x5a000008 + 4; // 10 mA drive
 
 	tdo_gpio_mode = MODE_GPIO(tdo_gpio);
 	tdi_gpio_mode = MODE_GPIO(tdi_gpio);


### PR DESCRIPTION
An issue was found on the Raspberry Pi 3B+ (which may apply to other models) where the BCM2835 GPIO implementation can cause glitches. It looks a bit like this:

https://bunniefoo.com/bunnie/openocd-lone-glitch.png
https://bunniefoo.com/bunnie/openocd-serial-glitch.png

It seems that the GPIO unit on the BCM2835 runs at a much slower clock rate (maybe 125MHz based on the glitch width?) and somehow data committed to/from the CPU is not synched correctly. This would manifest in set/clr events not executing immediately, and also stale data being stuck on the read path. This synch failure could either be due to a cache coherence bug, or it could be a clock domain synchronizer that's not quite working right. My guess is it's the latter -- the synchronizer may be holding off on passing the very last write or read until some arbitrary point later, could be that it misses a bus slot or whatever, but this leads to strictly the correct order of data, but the time at which the data arrives can be highly variable.

The glitches would happen maybe once every million cycles or so. The Xilinx XC7 FPGA is fast enough to actually respond to the glitch and continue working if the data levels are constant through the glitched clock, so in many cases the glitch would not lead to an improper configuration. However, we'd see a fault maybe once every few configurations, and SPI programming absolutely would not work with the BCM2835 module (works fine with sysfs). 

The fix is to insert a dummy read to the BCM2835 GPIO block before doing any read or write transaction. The read seems to flush the synchronizer or cache so that things are in a good state for the next operation. 

The downside is that the read is slow, this limits the overall bitbang rate, but at least it works as intended.
